### PR TITLE
Correctly parse reconciled transactions

### DIFF
--- a/grammar/ledger.ne
+++ b/grammar/ledger.ne
@@ -66,16 +66,17 @@ element ->
   | %comment     {% ([c]) => { return { type: 'comment', blockLine: c.line, value: c.value } } %}
   | alias        {% ([a]) => { var l = a.blockLine; delete a.blockLine; return { type: 'alias', blockLine: l, value: a } } %}
 
-transaction -> %date %ws check:? %payee %comment:? %newline expenselines
+transaction -> %date %ws reconciled:? check:? %payee %comment:? %newline expenselines
                                                   {%
                                                     function(d) {
                                                       return {
                                                         blockLine: d[0].line,
                                                         date: d[0].value,
-                                                        check: d[2] || undefined,
-                                                        payee: d[3].value,
-                                                        comment: d[4]?.value || undefined,
-                                                        expenselines: d[6]
+                                                        reconcile: d[2] || '',
+                                                        check: d[3] || undefined,
+                                                        payee: d[4].value,
+                                                        comment: d[5]?.value || undefined,
+                                                        expenselines: d[7]
                                                       }
                                                     }
                                                   %}

--- a/tests/nearly.test.ts
+++ b/tests/nearly.test.ts
@@ -33,6 +33,7 @@ describe('parsing multiple blocks', () => {
           value: {
             check: 1234,
             date: '2018-04-03',
+            reconcile: '',
             payee: 'Half & Price-Books',
             expenselines: [
               {
@@ -107,6 +108,7 @@ describe('parsing a transaction', () => {
             check: undefined,
             date: '2018-04-03',
             payee: 'Half Price Books',
+            reconcile: '',
             expenselines: [
               {
                 amount: 300,
@@ -146,6 +148,7 @@ describe('parsing a transaction', () => {
             check: undefined,
             date: '2018-04-03',
             payee: 'Half Price Books',
+            reconcile: '',
             expenselines: [
               {
                 amount: 300,
@@ -179,6 +182,7 @@ describe('parsing a transaction', () => {
             check: 1234,
             date: '2018-04-03',
             payee: 'Half Price Books',
+            reconcile: '',
             expenselines: [
               {
                 amount: 300,
@@ -212,6 +216,7 @@ describe('parsing a transaction', () => {
             check: 1234,
             date: '2018-04-03',
             payee: 'Half & Price-Books',
+            reconcile: '',
             expenselines: [
               {
                 amount: 3454500,
@@ -242,6 +247,41 @@ describe('parsing a transaction', () => {
           type: 'tx',
           blockLine: 1,
           value: {
+            reconcile: '',
+            check: 1234,
+            date: '2018-04-03',
+            payee: 'Half & Price-Books',
+            expenselines: [
+              {
+                amount: 300,
+                currency: '$',
+                account: 'Expenses:Books',
+                reconcile: '',
+              },
+              {
+                amount: 300,
+                currency: '$',
+                account: 'Assets:Checking',
+                reconcile: '',
+              },
+            ],
+          },
+        },
+      ],
+    ]);
+  });
+  test('when the expense has reconciliation', () => {
+    parser.feed('2018-04-03 * (1234) Half & Price-Books\n');
+    parser.feed('    Expenses:Books   $300\n');
+    parser.feed('    Assets:Checking  $300');
+
+    expect(parser.results).toEqual([
+      [
+        {
+          type: 'tx',
+          blockLine: 1,
+          value: {
+            reconcile: '*',
             check: 1234,
             date: '2018-04-03',
             payee: 'Half & Price-Books',
@@ -279,6 +319,7 @@ describe('parsing a transaction', () => {
             check: 1234,
             date: '2018-04-03',
             payee: 'Half Price Books',
+            reconcile: '',
             expenselines: [
               {
                 comment: 'This is a comment',
@@ -314,6 +355,7 @@ describe('parsing a transaction', () => {
           value: {
             date: '2018-04-03',
             payee: 'Half Price Books',
+            reconcile: '',
             expenselines: [
               {
                 amount: 300,


### PR DESCRIPTION
Fixes #9 partially. I'm still unsure about how to use this in parser.ts and would appreciate some guidance.

My tests also might not be the best, would appreciate suggestions.