### PR TITLE
Handle negative signs in front of currencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ data.json
 # Generated Files
 
 grammar/ledger.ts
+grammar/ledger.ts-e

--- a/grammar/ledger.ne
+++ b/grammar/ledger.ne
@@ -33,7 +33,7 @@
         check: { match: /\([0-9]+\)[ \t]+/, value: (s:string) => s.trim().slice(1, -1) },
         ws:     /[ \t]+/,
         reconciled: /[!*]/,
-        payee: { match: /[^!*;#|\n]+/, value: (s:string) => s.trim() },
+        payee: { match: /[^!*;#|\n][^!;#|\n]+/, value: (s:string) => s.trim() },
         comment: { match: /[;#|][^\n]+/, value: (s:string) => s.slice(1).trim() },
         newline: { match: '\n', lineBreaks: true, next: 'expenseLine'},
       },

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -546,6 +546,43 @@ describe('parsing a ledger file', () => {
       expect(txCache.transactions).toHaveLength(1);
       expect(txCache.transactions[0]).toEqual(expected);
     });
+    test('Stars in payee are supported', () => {
+      const contents = `2021/04/21	CardNr.*******1234
+	    e:Spending Money
+	    b:CreditUnion			-$20.00`;
+      const txCache = parse(contents, settings);
+      const expected: EnhancedTransaction = {
+        type: 'tx',
+        blockLine: 1,
+        block: {
+          firstLine: 0,
+          lastLine: 2,
+          block: contents,
+        },
+        value: {
+          date: '2021/04/21',
+          payee: 'CardNr.*******1234',
+          expenselines: [
+            {
+              account: 'e:Spending Money',
+              dealiasedAccount: 'e:Spending Money',
+              amount: 20,
+              currency: '$',
+              reconcile: '',
+            },
+            {
+              account: 'b:CreditUnion',
+              dealiasedAccount: 'b:CreditUnion',
+              amount: -20,
+              currency: '$',
+              reconcile: '',
+            },
+          ],
+        },
+      };
+      expect(txCache.transactions).toHaveLength(1);
+      expect(txCache.transactions[0]).toEqual(expected);
+    });
     test('A parsing error tags the result accordingly', () => {
       const contents = `2021/04/20 Obsidian
       e:Spending Money    $20.00


### PR DESCRIPTION
Hi there!
I am streamlining my workflow a bit, and am trying to use https://github.com/cantino/reckon to improve importing transactions.
It does use a bit different of a style for signs though, `-$20.00` instead of `$-20.00`.
Hope this is an acceptable way of implementing it :)