### PR TITLE
Add prefill support for obsidian://ledger links

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { getTransactionCache, LedgerModifier } from './file-interface';
 import { billIcon } from './graphics';
 import { LedgerView, LedgerViewType } from './ledgerview';
-import type { TransactionCache } from './parser';
+import type { EnhancedTransaction, TransactionCache } from './parser';
 import { ISettings, settingsWithDefaults } from './settings';
 import { SettingsTab } from './settings-tab';
 import type { default as MomentType } from 'moment';
@@ -268,9 +268,36 @@ ${window.moment().format('YYYY-MM-DD')} Starting Balances
   private readonly handleProtocolAction = async (
     params: ObsidianProtocolData,
   ): Promise<void> => {
-    // TODO: Support pre-populating fields, or even completely skipping the form
-    // by passing the correct data here.
+    let transaction: EnhancedTransaction = {
+      type: 'tx',
+      blockLine: 1,
+      block: {
+        firstLine: 0,
+        lastLine: 1,
+        block: '',
+      },
+      value: {
+        date: params.date || '',
+        payee: params.payee || '',
+        comment: params.comment || '',
+        expenselines: [
+          {
+            account: params.toaccount || '',
+            dealiasedAccount: params.toaccount || '',
+            amount: Number(params.amount) || 0,
+            currency: params.currency,
+            reconcile: '',
+          },
+          {
+            account: params.fromaccount || '',
+            dealiasedAccount: params.fromaccount || '',
+            amount: -Number(params.amount) || 0,
+            reconcile: '',
+          }
+        ],
+      },
+    }
     const ledgerFile = await this.createLedgerFileIfMissing();
-    new LedgerModifier(this, ledgerFile).openExpenseModal('new');
+    new LedgerModifier(this, ledgerFile).openExpenseModal('clone', transaction);
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { LedgerView, LedgerViewType } from './ledgerview';
 import type { EnhancedTransaction, TransactionCache } from './parser';
 import { ISettings, settingsWithDefaults } from './settings';
 import { SettingsTab } from './settings-tab';
+import moment from 'moment';
 import type { default as MomentType } from 'moment';
 import { around } from 'monkey-around';
 import {
@@ -277,7 +278,7 @@ ${window.moment().format('YYYY-MM-DD')} Starting Balances
         block: '',
       },
       value: {
-        date: params.date || '',
+        date: params.date || moment().format('YYYY-MM-DD'),
         payee: params.payee || '',
         comment: params.comment || '',
         expenselines: [


### PR DESCRIPTION
# Pull Request Description

This PR adds basic support for prefilled fields for the Obsidian Protocol handler.

Calling the uri will open the Add to Ledger modal with
A uri call may look like the following:
`obsidian://ledger?amount=100&payee=Groceries`

**Supported fields:**

- `amount`
- `date`
- `payee`
- `toaccount`
- `fromaccount`
- `currency`

# Known Issues

- `amount` defaults to `0` instead of a blank field.
  - This is a typing issue. Changing the accepted type on the object class might solve this but possibly introduce issues elsewhere.
- `currency`, while it works, is not reflected in the UI which will show your Currency Symbol as selected in the settings.
  - Additionally, it successfully defaults to the selected currency despite not having been specified. Perhaps this implementation ought to be more explicit.
- Modal will fail to load if run while Obsidian is not already running.
  - This is already the case with the current codebase, and seems to already be documented in #78.
