### PR TITLE
Add multicurrency support

### DIFF
--- a/src/balance-utils.ts
+++ b/src/balance-utils.ts
@@ -168,9 +168,12 @@ export type DailyAccountBalanceChangeMap = Map<string, Map<string, number>>;
  * If an account has no balance change on a date, that key will not be included
  * in the inner map. If a date has no transactions, that key will not be
  * included in the outer map.
+ * 
+ * Only transactions matching the passed currencySymbol will be included.
  */
 export const makeDailyAccountBalanceChangeMap = (
   transactions: EnhancedTransaction[],
+  currencySymbol: string,
 ): DailyAccountBalanceChangeMap => {
   // This map contains a mapping from every day (YYYY-MM-DD) to account names to
   // a list of all balance changes.
@@ -189,6 +192,10 @@ export const makeDailyAccountBalanceChangeMap = (
     tx.value.expenselines.forEach((line) => {
       if (!('account' in line)) {
         return; // Must be a comment line
+      }
+
+      if (line.currency != currencySymbol) {
+          return;
       }
 
       getWithDefault(

--- a/src/transaction-utils.ts
+++ b/src/transaction-utils.ts
@@ -55,6 +55,44 @@ export const getTotal = (
   return currency + total.toFixed(2);
 };
 
+/**
+ * getCurrencyTotals returns the total values of the transaction. It returns a
+ * string separated by newlines, with a line for each currency.
+ */
+export const getCurrencyTotals = (
+    tx: EnhancedTransaction
+): string => {
+    let totals: Map<string, number> = new Map<string, number>();
+
+    console.log(tx.value.expenselines);
+
+    let currentSignPositive = null;
+
+    for (let i = 0; i < tx.value.expenselines.length; i++) {
+        const line = tx.value.expenselines[i];
+
+        if ('currency' in line && line.currency) {
+            // Track the sign of the first value and skip lines that differ.
+            // We continue instead of breaking in case the transactions flip-flop
+            // between positive and negative, as unlikely as that is.
+            if (currentSignPositive === null) {
+                currentSignPositive = line.amount >= 0;
+            } else if (currentSignPositive === (line.amount < 0)) {
+                continue;
+            }
+
+            if (!totals.has(line.currency)) {
+                totals.set(line.currency, 0);
+            }
+
+            totals.set(line.currency, totals.get(line.currency)! + line.amount);
+        }
+    }
+
+    return Array.from(totals).map(([key, value]) => key + value.toFixed(2)).join("\n");
+};
+
+
 export const getTotalAsNum = (tx: EnhancedTransaction): number => {
   // The total of an EnhancedTransaction is -1 * the last line that is not a comment
   for (let i = tx.value.expenselines.length - 1; i >= 0; i--) {

--- a/src/ui/LedgerDashboard.tsx
+++ b/src/ui/LedgerDashboard.tsx
@@ -97,6 +97,7 @@ const DesktopDashboard: React.FC<{
 
     const changeMap = makeDailyAccountBalanceChangeMap(
       props.txCache.transactions,
+      props.settings.currencySymbol,
     );
     const balanceMap = makeDailyBalanceMap(
       props.txCache.accounts,

--- a/src/ui/TransactionList.tsx
+++ b/src/ui/TransactionList.tsx
@@ -10,6 +10,7 @@ import {
   filterByStartDate,
   filterTransactions,
   getTotal,
+  getCurrencyTotals,
 } from '../transaction-utils';
 import { Moment } from 'moment';
 import React from 'react';
@@ -178,7 +179,7 @@ const buildTableRows = (
       return {
         date: tx.value.date,
         payee: tx.value.payee,
-        total: getTotal(tx, currencySymbol),
+        total: getCurrencyTotals(tx),
         from: nonCommentLines[1].account,
         to: nonCommentLines[0].account,
         actions: makeClone(tx),
@@ -188,7 +189,7 @@ const buildTableRows = (
     return {
       date: tx.value.date,
       payee: tx.value.payee,
-      total: getTotal(tx, currencySymbol),
+      total: getCurrencyTotals(tx),
       from: nonCommentLines[nonCommentLines.length - 1].account,
       to: <i>Multiple</i>,
       actions: makeClone(tx),
@@ -342,7 +343,9 @@ const TransactionTable: React.FC<{
             return (
               <tr {...row.getRowProps()}>
                 {row.cells.map((cell) => (
-                  <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
+                    // Whitespace styling to support Total column newlines
+                    // There's definitely a better way to style this.
+                    <td style={{ whiteSpace: "pre" }} {...cell.getCellProps()}>{cell.render('Cell')}</td>
                 ))}
               </tr>
             );

--- a/src/ui/TransactionList.tsx
+++ b/src/ui/TransactionList.tsx
@@ -201,7 +201,7 @@ const buildTableRows = (
     const aDate = window.moment(a.date);
     const bDate = window.moment(b.date);
     if (aDate.isSame(bDate)) {
-      return 0;
+      return -1;
     }
     return aDate.isBefore(bDate) ? 1 : -1;
   });

--- a/tests/balance-utils.test.ts
+++ b/tests/balance-utils.test.ts
@@ -197,7 +197,7 @@ describe('Balance maps', () => {
   describe('makeDailyAccountBalanceChangeMap()', () => {
     test('simple test', () => {
       const input = [tx4, tx5, tx6];
-      const result = makeDailyAccountBalanceChangeMap(input);
+      const result = makeDailyAccountBalanceChangeMap(input, "");
       expect(result).toEqual(expectedDailyAccountBalanceChangeMap);
     });
   });


### PR DESCRIPTION
# Pull Request Description

This PR adds slightly more robust methods for dealing with/parsing multiple currencies.

**Main changes:**
- Balance graph now only shows transactions/balances with the Currency Symbol specified in the settings, instead of summing all values and ignoring the currency.
- Transaction list now correctly lists totals of each different currency, instead of summing all values and ignoring the currency.
- (Internal) `fillMissingAmount` method now correctly balances multiple currencies.

# Known Issues

- Balance graph only shows a singular currency, that specified in the settings. While this is sufficient for my own personal use it may be a good idea to add graph views supporting the other currencies.
- Unable to add transaction with multiple currencies with the modal. (You can still do it manually)
- Attempting to edit a transaction with multiple currencies with the modal fails (appears to cause the same error as #51).
  - Given that multiple currencies are not really supported in the UI to begin with this may not be a huge issue. Perhaps a "not supported" modal could show up when trying to edit such transactions?
- No tests.
  - I was unable to get the testing environment to work on my machine, so I was unable to ensure tests ran/write new tests.
  - Given the amount of changes made to the backend, tests should be written for the new functionality (and existing functionality retested) before this PR can be accepted.