### PR TITLE
Feature/spending breakdown

### DIFF
--- a/src/account-spending-utils.ts
+++ b/src/account-spending-utils.ts
@@ -1,0 +1,288 @@
+import type { EnhancedTransaction } from './parser';
+import { Moment } from 'moment';
+
+export interface ExpenseCategoryRow {
+  category: string;
+  amount: number;
+  percentage: number;
+  subcategories?: ExpenseCategoryRow[];
+}
+
+export interface ExpenseBreakdownResult {
+  rows: ExpenseCategoryRow[];
+  totalExpenses: number;
+}
+
+/**
+ * Normalizes a prefix to include both singular and plural forms.
+ * E.g., "Expenses" → ["expenses", "expense"]
+ */
+const normalizePrefixes = (prefix: string): string[] => {
+  const base = prefix.trim().replace(/:+$/, '').toLowerCase();
+  if (base.endsWith('s')) {
+    return [base, base.slice(0, -1)]; // "expenses" → ["expenses", "expense"]
+  }
+  return [base, `${base}s`]; // "expense" → ["expense", "expenses"]
+};
+
+export const calculateExpenseBreakdown = (
+  transactions: EnhancedTransaction[],
+  expensePrefix: string,
+  startDate: Moment,
+  endDate: Moment,
+): ExpenseBreakdownResult => {
+  const startBoundary = startDate.clone().startOf('day');
+  const endBoundary = endDate.clone().endOf('day');
+  const prefixes = normalizePrefixes(expensePrefix);
+
+  // Track amounts hierarchically: parent -> subcategory -> amount
+  const hierarchicalTotals = new Map<string, Map<string, number>>();
+  let totalExpenses = 0;
+
+  transactions.forEach((tx) => {
+    const txDate = window.moment(tx.value.date);
+    if (txDate.isBefore(startBoundary) || txDate.isAfter(endBoundary)) {
+      return;
+    }
+
+    tx.value.expenselines.forEach((line) => {
+      if (!('dealiasedAccount' in line)) {
+        return;
+      }
+
+      const accountLower = line.dealiasedAccount.toLowerCase();
+      if (!prefixes.some((p) => accountLower.startsWith(p))) {
+        return;
+      }
+
+      // Extract category hierarchy: e.g., "Expenses:Food:Groceries" -> ["Food", "Groceries"]
+      const parts = line.dealiasedAccount.split(':');
+      if (parts.length < 2) {
+        return; // Skip if no category structure
+      }
+
+      const parentCategory = parts[1];
+      const subcategory = parts.length > 2 ? parts.slice(2).join(':') : null;
+
+      // Initialize parent category map if needed
+      if (!hierarchicalTotals.has(parentCategory)) {
+        hierarchicalTotals.set(parentCategory, new Map<string, number>());
+      }
+
+      const subcategoryMap = hierarchicalTotals.get(parentCategory)!;
+
+      if (subcategory) {
+        // Track subcategory amount
+        const current = subcategoryMap.get(subcategory) || 0;
+        subcategoryMap.set(subcategory, current + line.amount);
+      } else {
+        // Track parent-level amount (no subcategory)
+        const current = subcategoryMap.get('_parent') || 0;
+        subcategoryMap.set('_parent', current + line.amount);
+      }
+
+      totalExpenses += line.amount;
+    });
+  });
+
+  // Convert to array with percentages
+  const rows: ExpenseCategoryRow[] = [];
+  hierarchicalTotals.forEach((subcategoryMap, parentCategory) => {
+    // Calculate total for this parent category
+    let parentTotal = 0;
+    subcategoryMap.forEach((amount) => {
+      parentTotal += amount;
+    });
+
+    if (parentTotal === 0) {
+      return; // Skip zero amounts
+    }
+
+    const subcategories: ExpenseCategoryRow[] = [];
+
+    // Process subcategories
+    subcategoryMap.forEach((amount, subcat) => {
+      if (subcat === '_parent') {
+        return; // Skip parent-level entries for now
+      }
+      if (amount !== 0) {
+        subcategories.push({
+          category: subcat,
+          amount,
+          // Subcategory percentage is relative to its parent
+          percentage: (amount / parentTotal) * 100,
+        });
+      }
+    });
+
+    // Sort subcategories by amount descending
+    subcategories.sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+
+    rows.push({
+      category: parentCategory,
+      amount: parentTotal,
+      // Parent percentage is relative to total expenses
+      percentage: totalExpenses === 0 ? 0 : (parentTotal / totalExpenses) * 100,
+      subcategories: subcategories.length > 0 ? subcategories : undefined,
+    });
+  });
+
+  // Sort by amount descending
+  rows.sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+
+  return { rows, totalExpenses };
+};
+
+/**
+ * Calculates the closing net worth (Assets + Liabilities) as of endDate.
+ * Includes ALL transactions from the beginning of time up to and including endDate.
+ * Strictly excludes transactions after endDate.
+ */
+export const calculateClosingNetWorth = (
+  transactions: EnhancedTransaction[],
+  assetPrefix: string,
+  liabilityPrefix: string,
+  endDate: Moment,
+): number => {
+  const endBoundary = endDate.clone().endOf('day');
+  const normalizedAssetPrefix = assetPrefix.trim().replace(/:+$/, '').toLowerCase();
+  const normalizedLiabilityPrefix = liabilityPrefix.trim().replace(/:+$/, '').toLowerCase();
+
+  let netWorth = 0;
+
+  transactions.forEach((tx) => {
+    const txDate = window.moment(tx.value.date);
+    // Only include transactions up to and including endDate
+    if (txDate.isAfter(endBoundary)) {
+      return;
+    }
+
+    tx.value.expenselines.forEach((line) => {
+      if (!('dealiasedAccount' in line)) {
+        return;
+      }
+
+      const accountLower = line.dealiasedAccount.toLowerCase();
+      if (
+        accountLower.startsWith(normalizedAssetPrefix) ||
+        accountLower.startsWith(normalizedLiabilityPrefix)
+      ) {
+        netWorth += line.amount;
+      }
+    });
+  });
+
+  return netWorth;
+};
+
+export interface AssetCategoryRow {
+  category: string;
+  amount: number;
+  subcategories?: AssetCategoryRow[];
+}
+
+/**
+ * Calculates the breakdown of assets and liabilities by top-level category as of endDate.
+ * Includes ALL transactions from the beginning of time up to and including endDate.
+ */
+export const calculateAssetBreakdown = (
+  transactions: EnhancedTransaction[],
+  assetPrefix: string,
+  liabilityPrefix: string,
+  endDate: Moment,
+): AssetCategoryRow[] => {
+  const endBoundary = endDate.clone().endOf('day');
+  const normalizedAssetPrefix = assetPrefix.trim().replace(/:+$/, '').toLowerCase();
+  const normalizedLiabilityPrefix = liabilityPrefix.trim().replace(/:+$/, '').toLowerCase();
+
+  // Track amounts hierarchically: parent -> subcategory -> amount
+  const hierarchicalTotals = new Map<string, Map<string, number>>();
+
+  transactions.forEach((tx) => {
+    const txDate = window.moment(tx.value.date);
+    if (txDate.isAfter(endBoundary)) {
+      return;
+    }
+
+    tx.value.expenselines.forEach((line) => {
+      if (!('dealiasedAccount' in line)) {
+        return;
+      }
+
+      const accountLower = line.dealiasedAccount.toLowerCase();
+      if (
+        accountLower.startsWith(normalizedAssetPrefix) ||
+        accountLower.startsWith(normalizedLiabilityPrefix)
+      ) {
+        // Extract category hierarchy: e.g., "Assets:Bank:Checking" -> ["Bank", "Checking"]
+        const parts = line.dealiasedAccount.split(':');
+        if (parts.length < 2) {
+          return; // Skip if no category structure
+        }
+
+        const parentCategory = parts[1];
+        const subcategory = parts.length > 2 ? parts.slice(2).join(':') : null;
+
+        // Initialize parent category map if needed
+        if (!hierarchicalTotals.has(parentCategory)) {
+          hierarchicalTotals.set(parentCategory, new Map<string, number>());
+        }
+
+        const subcategoryMap = hierarchicalTotals.get(parentCategory)!;
+
+        if (subcategory) {
+          // Track subcategory amount
+          const current = subcategoryMap.get(subcategory) || 0;
+          subcategoryMap.set(subcategory, current + line.amount);
+        } else {
+          // Track parent-level amount (no subcategory)
+          const current = subcategoryMap.get('_parent') || 0;
+          subcategoryMap.set('_parent', current + line.amount);
+        }
+      }
+    });
+  });
+
+  // Convert to array with subcategories
+  const rows: AssetCategoryRow[] = [];
+  hierarchicalTotals.forEach((subcategoryMap, parentCategory) => {
+    // Calculate total for this parent category
+    let parentTotal = 0;
+    subcategoryMap.forEach((amount) => {
+      parentTotal += amount;
+    });
+
+    if (parentTotal === 0) {
+      return; // Skip zero amounts
+    }
+
+    const subcategories: AssetCategoryRow[] = [];
+
+    // Process subcategories
+    subcategoryMap.forEach((amount, subcat) => {
+      if (subcat === '_parent') {
+        return; // Skip parent-level entries for now
+      }
+      if (amount !== 0) {
+        subcategories.push({
+          category: subcat,
+          amount,
+        });
+      }
+    });
+
+    // Sort subcategories by absolute amount descending
+    subcategories.sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+
+    rows.push({
+      category: parentCategory,
+      amount: parentTotal,
+      subcategories: subcategories.length > 0 ? subcategories : undefined,
+    });
+  });
+
+  // Sort by absolute amount descending
+  rows.sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+
+  return rows;
+};

--- a/src/ui/AccountSpendingBreakdown.tsx
+++ b/src/ui/AccountSpendingBreakdown.tsx
@@ -1,0 +1,292 @@
+import type { TransactionCache } from '../parser';
+import { Moment } from 'moment';
+import React from 'react';
+import styled from 'styled-components';
+import {
+  calculateExpenseBreakdown,
+  calculateClosingNetWorth,
+  calculateAssetBreakdown,
+} from '../account-spending-utils';
+
+const Container = styled.div`
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+`;
+
+const TableWrapper = styled.div`
+  overflow-x: auto;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  border-spacing: 0;
+  border: 1px solid var(--background-modifier-border);
+
+  th,
+  td {
+    padding: 0.5rem;
+    border-bottom: 1px solid var(--background-modifier-border);
+  }
+
+  th {
+    text-align: left;
+    background: var(--background-primary-alt);
+  }
+
+  tr:last-child td {
+    border-bottom: 0;
+  }
+`;
+
+const EmptyState = styled.p`
+  color: var(--text-muted);
+  margin: 0.5rem 0 0;
+`;
+
+const SummaryRow = styled.tr`
+  font-weight: bold;
+  background: var(--background-secondary);
+`;
+
+const ClickableRow = styled(SummaryRow)`
+  cursor: pointer;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: var(--background-modifier-hover);
+  }
+`;
+
+const SubRow = styled.tr`
+  background: var(--background-secondary-alt);
+  font-size: 0.9em;
+
+  td:first-child {
+    padding-left: 1.5rem;
+  }
+`;
+
+const DeepSubRow = styled.tr`
+  background: var(--background-secondary-alt);
+  font-size: 0.85em;
+
+  td:first-child {
+    padding-left: 2.5rem;
+  }
+`;
+
+const formatAmount = (value: number, symbol: string): string => {
+  return `${symbol}${Math.abs(value).toFixed(2)}`;
+};
+
+const formatSignedAmount = (value: number, symbol: string): string => {
+  const sign = value < 0 ? '-' : '';
+  return `${sign}${symbol}${Math.abs(value).toFixed(2)}`;
+};
+
+interface AccountSpendingBreakdownProps {
+  txCache: TransactionCache;
+  startDate: Moment;
+  endDate: Moment;
+  currencySymbol: string;
+  expensePrefix: string;
+  assetPrefix: string;
+  liabilityPrefix: string;
+}
+
+export const AccountSpendingBreakdown: React.FC<AccountSpendingBreakdownProps> = (
+  props,
+): JSX.Element => {
+  const [isAssetBreakdownExpanded, setIsAssetBreakdownExpanded] = React.useState(false);
+  const [expandedCategories, setExpandedCategories] = React.useState<Set<string>>(new Set());
+  const [expandedAssetCategories, setExpandedAssetCategories] = React.useState<Set<string>>(new Set());
+
+  const toggleCategory = (category: string) => {
+    setExpandedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  };
+
+  const toggleAssetCategory = (category: string) => {
+    setExpandedAssetCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  };
+
+  // Calculate expense breakdown by category for the selected period
+  const { rows, totalExpenses } = React.useMemo(
+    () =>
+      calculateExpenseBreakdown(
+        props.txCache.transactions,
+        props.expensePrefix,
+        props.startDate,
+        props.endDate,
+      ),
+    [props.txCache, props.expensePrefix, props.startDate, props.endDate],
+  );
+
+  // Calculate closing net worth as of endDate (all transactions from beginning of time up to endDate)
+  const closingNetWorth = React.useMemo(
+    () =>
+      calculateClosingNetWorth(
+        props.txCache.transactions,
+        props.assetPrefix,
+        props.liabilityPrefix,
+        props.endDate,
+      ),
+    [props.txCache, props.assetPrefix, props.liabilityPrefix, props.endDate],
+  );
+
+  // Calculate asset breakdown by category
+  const assetBreakdown = React.useMemo(
+    () =>
+      calculateAssetBreakdown(
+        props.txCache.transactions,
+        props.assetPrefix,
+        props.liabilityPrefix,
+        props.endDate,
+      ),
+    [props.txCache, props.assetPrefix, props.liabilityPrefix, props.endDate],
+  );
+
+  if (rows.length === 0) {
+    return (
+      <Container>
+        <h3>Spending Breakdown</h3>
+        <EmptyState>No expenses found in this period.</EmptyState>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <h3>Spending Breakdown</h3>
+      <TableWrapper>
+        <Table>
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Amount</th>
+              <th>% of Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const hasSubcategories = row.subcategories && row.subcategories.length > 0;
+              const isExpanded = expandedCategories.has(row.category);
+
+              return (
+                <React.Fragment key={row.category}>
+                  {hasSubcategories ? (
+                    <ClickableRow
+                      onClick={() => toggleCategory(row.category)}
+                      title="Click to expand subcategories"
+                    >
+                      <td>
+                        {isExpanded ? '▼' : '▶'} {row.category}
+                      </td>
+                      <td>{formatAmount(row.amount, props.currencySymbol)}</td>
+                      <td>
+                        {row.percentage < 0.1
+                          ? '< 0.1%'
+                          : `${row.percentage.toFixed(1)}%`}
+                      </td>
+                    </ClickableRow>
+                  ) : (
+                    <tr>
+                      <td>{row.category}</td>
+                      <td>{formatAmount(row.amount, props.currencySymbol)}</td>
+                      <td>
+                        {row.percentage < 0.1
+                          ? '< 0.1%'
+                          : `${row.percentage.toFixed(1)}%`}
+                      </td>
+                    </tr>
+                  )}
+                  {hasSubcategories &&
+                    isExpanded &&
+                    row.subcategories!.map((subrow) => (
+                      <SubRow key={subrow.category}>
+                        <td>{subrow.category}</td>
+                        <td>{formatAmount(subrow.amount, props.currencySymbol)}</td>
+                        <td>
+                          {subrow.percentage < 0.1
+                            ? '< 0.1%'
+                            : `${subrow.percentage.toFixed(1)}%`}
+                        </td>
+                      </SubRow>
+                    ))}
+                </React.Fragment>
+              );
+            })}
+            <SummaryRow>
+              <td>Total Period Expenses</td>
+              <td>{formatAmount(totalExpenses, props.currencySymbol)}</td>
+              <td>100%</td>
+            </SummaryRow>
+            <ClickableRow
+              onClick={() => setIsAssetBreakdownExpanded(!isAssetBreakdownExpanded)}
+              title="Click to expand asset breakdown"
+            >
+              <td>
+                {isAssetBreakdownExpanded ? '▼' : '▶'} Total Assets Remaining
+              </td>
+              <td>{formatSignedAmount(closingNetWorth, props.currencySymbol)}</td>
+              <td></td>
+            </ClickableRow>
+            {isAssetBreakdownExpanded &&
+              assetBreakdown.map((row) => {
+                const hasSubcategories = row.subcategories && row.subcategories.length > 0;
+                const isExpanded = expandedAssetCategories.has(row.category);
+
+                return (
+                  <React.Fragment key={row.category}>
+                    {hasSubcategories ? (
+                      <SubRow
+                        as={ClickableRow}
+                        onClick={() => toggleAssetCategory(row.category)}
+                        title="Click to expand subcategories"
+                      >
+                        <td>
+                          {isExpanded ? '▼' : '▶'} {row.category}
+                        </td>
+                        <td>{formatSignedAmount(row.amount, props.currencySymbol)}</td>
+                        <td></td>
+                      </SubRow>
+                    ) : (
+                      <SubRow>
+                        <td>{row.category}</td>
+                        <td>{formatSignedAmount(row.amount, props.currencySymbol)}</td>
+                        <td></td>
+                      </SubRow>
+                    )}
+                    {hasSubcategories &&
+                      isExpanded &&
+                      row.subcategories!.map((subrow) => (
+                        <DeepSubRow key={subrow.category}>
+                          <td>{subrow.category}</td>
+                          <td>{formatSignedAmount(subrow.amount, props.currencySymbol)}</td>
+                          <td></td>
+                        </DeepSubRow>
+                      ))}
+                  </React.Fragment>
+                );
+              })}
+          </tbody>
+        </Table>
+      </TableWrapper>
+    </Container>
+  );
+};

--- a/src/ui/LedgerDashboard.tsx
+++ b/src/ui/LedgerDashboard.tsx
@@ -8,6 +8,7 @@ import type { TransactionCache } from '../parser';
 import { ISettings } from '../settings';
 import { AccountsList } from './AccountsList';
 import { AccountVisualization } from './AccountVisualization';
+import { AccountSpendingBreakdown } from './AccountSpendingBreakdown';
 import { DateRangeSelector } from './DateRangeSelector';
 import { NetWorthVisualization } from './NetWorthVisualization';
 import { ParseErrors } from './ParseErrors';
@@ -188,6 +189,19 @@ const DesktopDashboard: React.FC<{
                 startDate={startDate}
                 endDate={endDate}
               />
+              {selectedAccounts.some((account) =>
+                account.startsWith(props.settings.expenseAccountsPrefix)
+              ) && (
+                  <AccountSpendingBreakdown
+                    txCache={props.txCache}
+                    startDate={startDate}
+                    endDate={endDate}
+                    currencySymbol={props.settings.currencySymbol}
+                    expensePrefix={props.settings.expenseAccountsPrefix}
+                    assetPrefix={props.settings.assetAccountsPrefix}
+                    liabilityPrefix={props.settings.liabilityAccountsPrefix}
+                  />
+                )}
             </>
           )}
         </FlexMainContent>

--- a/tests/account-spending-breakdown.test.ts
+++ b/tests/account-spending-breakdown.test.ts
@@ -1,0 +1,250 @@
+import {
+  calculateExpenseBreakdown,
+  calculateClosingNetWorth,
+} from '../src/account-spending-utils';
+import { EnhancedExpenseLine, EnhancedTransaction, FileBlock } from '../src/parser';
+import * as moment from 'moment';
+
+declare global {
+  interface Window {
+    moment: typeof moment;
+  }
+}
+
+window.moment = moment as typeof window.moment;
+
+const emptyBlock: FileBlock = {
+  firstLine: -1,
+  lastLine: -1,
+  block: '',
+};
+
+const makeLine = (account: string, amount: number): EnhancedExpenseLine => ({
+  account,
+  dealiasedAccount: account,
+  amount,
+  reconcile: '',
+});
+
+const makeTx = (date: string, lines: EnhancedExpenseLine[]): EnhancedTransaction => ({
+  type: 'tx',
+  blockLine: -1,
+  block: emptyBlock,
+  value: {
+    date,
+    payee: 'Test',
+    expenselines: lines,
+  },
+});
+
+describe('calculateExpenseBreakdown', () => {
+  test('groups expenses by category and calculates percentages', () => {
+    const transactions = [
+      makeTx('2022-01-05', [
+        makeLine('Expenses:Food:Groceries', 40),
+        makeLine('Assets:Checking', -40),
+      ]),
+      makeTx('2022-01-06', [
+        makeLine('Expenses:Food:Dining', 25),
+        makeLine('Assets:Checking', -25),
+      ]),
+      makeTx('2022-01-10', [
+        makeLine('Expenses:Entertainment', 35),
+        makeLine('Assets:Checking', -35),
+      ]),
+    ];
+
+    const result = calculateExpenseBreakdown(
+      transactions,
+      'Expenses',
+      moment('2022-01-01'),
+      moment('2022-01-31'),
+    );
+
+    // Total expenses = 40 + 25 + 35 = 100
+    expect(result.totalExpenses).toBe(100);
+
+    // Two parent categories: Food (65) and Entertainment (35)
+    expect(result.rows).toHaveLength(2);
+
+    // Food category with subcategories
+    expect(result.rows[0].category).toBe('Food');
+    expect(result.rows[0].amount).toBe(65);
+    expect(result.rows[0].percentage).toBe(65); // 65/100 * 100
+    expect(result.rows[0].subcategories).toHaveLength(2);
+    expect(result.rows[0].subcategories![0]).toEqual({
+      category: 'Groceries',
+      amount: 40,
+      percentage: (40 / 65) * 100, // percentage relative to parent
+    });
+    expect(result.rows[0].subcategories![1]).toEqual({
+      category: 'Dining',
+      amount: 25,
+      percentage: (25 / 65) * 100, // percentage relative to parent
+    });
+
+    // Entertainment category without subcategories
+    expect(result.rows[1].category).toBe('Entertainment');
+    expect(result.rows[1].amount).toBe(35);
+    expect(result.rows[1].percentage).toBe(35); // 35/100 * 100
+    expect(result.rows[1].subcategories).toBeUndefined();
+  });
+
+  test('ignores transactions outside of the date range', () => {
+    const transactions = [
+      makeTx('2022-01-15', [
+        makeLine('Expenses:Travel', 100),
+        makeLine('Assets:Checking', -100),
+      ]),
+      makeTx('2022-02-15', [
+        makeLine('Expenses:Travel', 200),
+        makeLine('Assets:Checking', -200),
+      ]),
+    ];
+
+    const result = calculateExpenseBreakdown(
+      transactions,
+      'Expenses',
+      moment('2022-01-01'),
+      moment('2022-01-31'),
+    );
+
+    // Only January transaction should be included
+    expect(result.totalExpenses).toBe(100);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].category).toBe('Travel');
+    expect(result.rows[0].amount).toBe(100);
+  });
+
+  test('returns empty result when no expenses in range', () => {
+    const transactions = [
+      makeTx('2022-03-01', [
+        makeLine('Expenses:Utilities', 50),
+        makeLine('Assets:Checking', -50),
+      ]),
+    ];
+
+    const result = calculateExpenseBreakdown(
+      transactions,
+      'Expenses',
+      moment('2022-01-01'),
+      moment('2022-01-31'),
+    );
+
+    expect(result.totalExpenses).toBe(0);
+    expect(result.rows).toHaveLength(0);
+  });
+
+  test('handles deeply nested categories', () => {
+    const transactions = [
+      makeTx('2022-01-05', [
+        makeLine('Expenses:Food:Restaurant:FastFood', 20),
+        makeLine('Assets:Checking', -20),
+      ]),
+      makeTx('2022-01-06', [
+        makeLine('Expenses:Food:Restaurant:Dining', 30),
+        makeLine('Assets:Checking', -30),
+      ]),
+      makeTx('2022-01-10', [
+        makeLine('Expenses:Food:Groceries', 50),
+        makeLine('Assets:Checking', -50),
+      ]),
+    ];
+
+    const result = calculateExpenseBreakdown(
+      transactions,
+      'Expenses',
+      moment('2022-01-01'),
+      moment('2022-01-31'),
+    );
+
+    // Total expenses = 20 + 30 + 50 = 100
+    expect(result.totalExpenses).toBe(100);
+
+    // One parent category: Food (100)
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].category).toBe('Food');
+    expect(result.rows[0].amount).toBe(100);
+    expect(result.rows[0].subcategories).toHaveLength(3);
+
+    // Deep subcategories are joined with colons and appear as separate items
+    expect(result.rows[0].subcategories![0].category).toBe('Groceries');
+    expect(result.rows[0].subcategories![0].amount).toBe(50);
+    expect(result.rows[0].subcategories![1].category).toBe('Restaurant:Dining');
+    expect(result.rows[0].subcategories![1].amount).toBe(30);
+    expect(result.rows[0].subcategories![2].category).toBe('Restaurant:FastFood');
+    expect(result.rows[0].subcategories![2].amount).toBe(20);
+  });
+});
+
+describe('calculateClosingNetWorth', () => {
+  test('includes all transactions up to endDate', () => {
+    const transactions = [
+      makeTx('2022-01-10', [
+        makeLine('Assets:Checking', 1000),
+        makeLine('Income:Salary', -1000),
+      ]),
+      makeTx('2022-01-20', [
+        makeLine('Expenses:Food', 50),
+        makeLine('Assets:Checking', -50),
+      ]),
+      makeTx('2022-01-25', [
+        makeLine('Liabilities:CreditCard', -200),
+        makeLine('Assets:Checking', 200),
+      ]),
+    ];
+
+    const netWorth = calculateClosingNetWorth(
+      transactions,
+      'Assets',
+      'Liabilities',
+      moment('2022-01-31'),
+    );
+
+    // Assets: 1000 - 50 + 200 = 1150
+    // Liabilities: -200
+    // Net: 1150 + (-200) = 950
+    expect(netWorth).toBe(950);
+  });
+
+  test('excludes transactions after endDate', () => {
+    const transactions = [
+      makeTx('2022-01-15', [
+        makeLine('Assets:Checking', 1000),
+        makeLine('Income:Salary', -1000),
+      ]),
+      makeTx('2022-02-15', [
+        makeLine('Assets:Checking', 500),
+        makeLine('Income:Bonus', -500),
+      ]),
+    ];
+
+    const netWorth = calculateClosingNetWorth(
+      transactions,
+      'Assets',
+      'Liabilities',
+      moment('2022-01-31'),
+    );
+
+    // Only January transaction should be included
+    expect(netWorth).toBe(1000);
+  });
+
+  test('returns 0 when no asset or liability transactions', () => {
+    const transactions = [
+      makeTx('2022-01-10', [
+        makeLine('Expenses:Food', 50),
+        makeLine('Income:Salary', -50),
+      ]),
+    ];
+
+    const netWorth = calculateClosingNetWorth(
+      transactions,
+      'Assets',
+      'Liabilities',
+      moment('2022-01-31'),
+    );
+
+    expect(netWorth).toBe(0);
+  });
+});


### PR DESCRIPTION
Summary:
Adds a "Spending Breakdown" table that renders only when Expense accounts
are selected. The table shows expense categories with absolute amounts
and percentage contribution. A clickable "Total Assets Remaining" row
expands to display asset and liability category balances.

Closes #58
Related to #70. This PR surfaces precise asset balances at the category
level in the dashboard, laying groundwork for future per-account balance
display.


Changes:
- Added src/account-spending-utils.ts with utility functions:
  - calculateExpenseBreakdown()
    Groups expenses by top-level category and calculates percentages
  - calculateClosingNetWorth()
    Calculates net worth as of the selected end date
  - calculateAssetBreakdown()
    Breaks down assets and liabilities by category

- Created src/ui/AccountSpendingBreakdown.tsx
  - React component responsible for rendering the breakdown table

- Modified src/ui/LedgerDashboard.tsx
  - Conditionally renders the spending breakdown when Expense accounts
    are selected

- Added unit tests:
  - tests/account-spending-breakdown.test.ts

Testing:
- All 6 new unit tests pass
- Utility functions follow existing patterns used in balance-utils.ts
- Manual testing confirmed:
  - Breakdown appears only when Expense accounts are selected
  - Breakdown hides correctly when deselected
- Build completes successfully

Screenshots:
<img width="1300" height="415" alt="image" src="https://github.com/user-attachments/assets/6940c6c8-d294-4435-ac93-80a2ccd68b84" />
Screenshot shows the Spending Breakdown table with asset expansion enabled.



